### PR TITLE
Fix for missing toolbar in about screen (Issue #62)

### DIFF
--- a/app/src/main/java/me/writeily/pro/model/Constants.java
+++ b/app/src/main/java/me/writeily/pro/model/Constants.java
@@ -41,4 +41,7 @@ public class Constants {
     public static final String DARK_MD_HTML_PREFIX = "<html><head><style type=\"text/css\">html,body{padding:4px 8px 4px 8px;font-family:'sans-serif-light';color:#ffffff;background-color:#303030}h1,h2,h3,h4,h5,h6{font-family:'sans-serif-condensed';}a{color:#ffffff;text-decoration:underline;}a:visited{color:#dddddd}}</style></head><body>";
     public static final String MD_HTML_SUFFIX = "</body></html>";
     public static final String NOTE_SOURCE_DIR = "note_source_dir";
+
+    // ----- INTENT EXTRAS -----
+    public static final String INTENT_EXTRA_SHOW_ABOUT = "writeily.intent.settings.ABOUT";
 }

--- a/app/src/main/java/me/writeily/pro/settings/AboutFragment.java
+++ b/app/src/main/java/me/writeily/pro/settings/AboutFragment.java
@@ -1,0 +1,19 @@
+package me.writeily.pro.settings;
+
+import android.os.Bundle;
+import android.preference.PreferenceFragment;
+
+import me.writeily.pro.R;
+
+/**
+ * Created by Minty123 on 2015-01-15.
+ */
+public class AboutFragment extends PreferenceFragment {
+
+    @Override
+    public void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        addPreferencesFromResource(R.xml.about_screen);
+    }
+
+}

--- a/app/src/main/java/me/writeily/pro/settings/SettingsActivity.java
+++ b/app/src/main/java/me/writeily/pro/settings/SettingsActivity.java
@@ -9,11 +9,12 @@ import android.support.v7.widget.Toolbar;
 import android.view.MenuItem;
 
 import me.writeily.pro.R;
+import me.writeily.pro.model.Constants;
 
 /**
  * Created by jeff on 2014-04-11.
  */
-public class SettingsActivity extends ActionBarActivity implements SettingsFragment.OnThemeChangedListener {
+public class SettingsActivity extends ActionBarActivity implements SettingsFragment.WriteilySettingsListener {
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -36,9 +37,19 @@ public class SettingsActivity extends ActionBarActivity implements SettingsFragm
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
 
-        getFragmentManager().beginTransaction()
-                .replace(R.id.frame, new SettingsFragment())
-                .commit();
+        // Show main settings page or about screen?
+        boolean showAbout = getIntent().getBooleanExtra(Constants.INTENT_EXTRA_SHOW_ABOUT, false);
+
+        if (!showAbout) {
+            getFragmentManager().beginTransaction()
+                    .replace(R.id.frame, new SettingsFragment())
+                    .commit();
+        } else {
+            setTitle(R.string.pref_about_dialog_title);
+            getFragmentManager().beginTransaction()
+                    .replace(R.id.frame, new AboutFragment())
+                    .commit();
+        }
     }
 
     @Override
@@ -61,6 +72,13 @@ public class SettingsActivity extends ActionBarActivity implements SettingsFragm
         finish();
 
         overridePendingTransition(0, 0);
+        startActivity(intent);
+    }
+
+    @Override
+    public void onAboutClicked() {
+        Intent intent = getIntent();
+        intent.putExtra(Constants.INTENT_EXTRA_SHOW_ABOUT, true);
         startActivity(intent);
     }
 }

--- a/app/src/main/java/me/writeily/pro/settings/SettingsFragment.java
+++ b/app/src/main/java/me/writeily/pro/settings/SettingsFragment.java
@@ -20,7 +20,7 @@ import me.writeily.pro.model.Constants;
  */
 public class SettingsFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
 
-    OnThemeChangedListener mCallback;
+    WriteilySettingsListener mCallback;
     CheckBoxPreference pinPreference;
     Context context;
 
@@ -51,6 +51,22 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
 
         // Register PreferenceChangeListener
         getPreferenceManager().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+
+        // Workaround for About-Screen
+        Preference aboutScreen = (Preference) findPreference(getString(R.string.pref_about_key));
+        aboutScreen.setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
+            @Override
+            public boolean onPreferenceClick(Preference preference) {
+                if (mCallback == null) {
+                    return false;
+                }
+
+                mCallback.onAboutClicked();
+                return true;
+            }
+        });
+
+
     }
 
     @Override
@@ -81,7 +97,7 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
 
         // Make sure the container has implemented the callback interface
         try {
-            mCallback = (OnThemeChangedListener) activity;
+            mCallback = (WriteilySettingsListener) activity;
         } catch (ClassCastException e) {
             throw new ClassCastException(activity.toString()
                     + "must implement OnThemeChangedListener");
@@ -89,7 +105,9 @@ public class SettingsFragment extends PreferenceFragment implements SharedPrefer
     }
 
     // Needed for callback to container activity
-    public interface OnThemeChangedListener {
+    public interface WriteilySettingsListener {
         public void onThemeChanged();
+
+        public void onAboutClicked();
     }
 }

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -14,6 +14,7 @@
     <string name="pref_theme_key">pref_theme</string>
     <string name="pref_font_size_key">pref_font_size_key</string>
     <string name="pref_email_key">pref_email_key</string>
+    <string name="pref_about_key">pref_about</string>
 
     <string name="twitter_url">https://twitter.com/writeily</string>
     <string name="writeily_url">https://play.google.com/store/apps/details?id=me.writeily.pro</string>

--- a/app/src/main/res/xml/about_screen.xml
+++ b/app/src/main/res/xml/about_screen.xml
@@ -1,0 +1,69 @@
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+    <Preference
+        android:summary="@string/app_version"
+        android:title="@string/about_version_title" />
+
+    <Preference
+        android:summary="@string/tap_website"
+        android:title="@string/about_source_title">
+        <intent
+            android:action="android.intent.action.VIEW"
+            android:data="@string/source_url" />
+    </Preference>
+
+    <PreferenceCategory android:title="@string/about_developer_section">
+        <Preference
+            android:summary="@string/tap_website"
+            android:title="@string/main_developer">
+            <intent
+                android:action="android.intent.action.VIEW"
+                android:data="@string/main_developer_url" />
+        </Preference>
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/about_contributors_section">
+        <Preference
+            android:summary="@string/tap_github"
+            android:title="@string/contributor_minty123">
+            <intent
+                android:action="android.intent.action.VIEW"
+                android:data="@string/contributor_minty123_url" />
+        </Preference>
+
+        <Preference
+            android:summary="@string/tap_github"
+            android:title="@string/contributor_davydsantos">
+            <intent
+                android:action="android.intent.action.VIEW"
+                android:data="@string/contributor_davydsantos_url" />
+        </Preference>
+
+        <Preference
+            android:summary="@string/tap_github"
+            android:title="@string/contributor_patcon">
+            <intent
+                android:action="android.intent.action.VIEW"
+                android:data="@string/contributor_patcon_url" />
+        </Preference>
+
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/about_translators_section">
+        <Preference
+            android:summary="@string/translators_german"
+            android:title="@string/about_german" />
+
+        <Preference
+            android:summary="@string/translators_polish"
+            android:title="@string/about_polish" />
+    </PreferenceCategory>
+
+    <PreferenceCategory android:title="@string/about_libraries_section">
+        <Preference
+            android:summary="@string/licence_apache20"
+            android:title="@string/library_anddown" />
+    </PreferenceCategory>
+
+</PreferenceScreen>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -76,75 +76,11 @@
                 android:data="@string/writeily_donate_url" />
         </Preference>
 
-        <PreferenceScreen
-            android:key="about"
-            android:title="@string/pref_about_dialog_title">
+        <Preference
+            android:key="@string/pref_about_key"
+            android:title="@string/pref_about_dialog_title" />
 
-            <Preference
-                android:summary="@string/app_version"
-                android:title="@string/about_version_title" />
-
-            <Preference
-                android:summary="@string/tap_website"
-                android:title="@string/about_source_title">
-                <intent
-                    android:action="android.intent.action.VIEW"
-                    android:data="@string/source_url" />
-            </Preference>
-
-            <PreferenceCategory android:title="@string/about_developer_section">
-                <Preference
-                    android:summary="@string/tap_website"
-                    android:title="@string/main_developer">
-                    <intent
-                        android:action="android.intent.action.VIEW"
-                        android:data="@string/main_developer_url" />
-                </Preference>
-            </PreferenceCategory>
-
-            <PreferenceCategory android:title="@string/about_contributors_section">
-                <Preference
-                    android:summary="@string/tap_github"
-                    android:title="@string/contributor_minty123">
-                    <intent
-                        android:action="android.intent.action.VIEW"
-                        android:data="@string/contributor_minty123_url" />
-                </Preference>
-
-                <Preference
-                    android:summary="@string/tap_github"
-                    android:title="@string/contributor_davydsantos">
-                    <intent
-                        android:action="android.intent.action.VIEW"
-                        android:data="@string/contributor_davydsantos_url" />
-                </Preference>
-
-                <Preference
-                    android:summary="@string/tap_github"
-                    android:title="@string/contributor_patcon">
-                    <intent
-                        android:action="android.intent.action.VIEW"
-                        android:data="@string/contributor_patcon_url" />
-                </Preference>
-
-            </PreferenceCategory>
-
-            <PreferenceCategory android:title="@string/about_translators_section">
-                <Preference
-                    android:summary="@string/translators_german"
-                    android:title="@string/about_german"></Preference>
-
-                <Preference
-                    android:summary="@string/translators_polish"
-                    android:title="@string/about_polish"></Preference>
-            </PreferenceCategory>
-
-            <PreferenceCategory android:title="@string/about_libraries_section">
-                <Preference
-                    android:summary="@string/licence_apache20"
-                    android:title="@string/library_anddown"></Preference>
-            </PreferenceCategory>
-        </PreferenceScreen>
     </PreferenceCategory>
+
 
 </PreferenceScreen>


### PR DESCRIPTION
This fix is a workaround for what is possibly a bug on AppCompat v21.
Clicking the about entry in the settings will launch a new SettingsActivity
that shows the about screen instead of the main settings page.