### PR TITLE
Syntax highlighting

### DIFF
--- a/app/src/main/java/me/writeily/pro/NoteActivity.java
+++ b/app/src/main/java/me/writeily/pro/NoteActivity.java
@@ -17,7 +17,6 @@ import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.LinearLayout;
-import android.widget.RelativeLayout;
 import android.widget.ScrollView;
 
 import java.io.File;
@@ -26,6 +25,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
 
+import me.writeily.pro.editor.HighlightingEditor;
 import me.writeily.pro.model.Constants;
 import me.writeily.pro.model.WriteilySingleton;
 
@@ -38,7 +38,7 @@ public class NoteActivity extends ActionBarActivity {
     private Context context;
 
     private EditText noteTitle;
-    private EditText content;
+    private HighlightingEditor content;
     private ScrollView scrollView;
 
     private ViewGroup keyboardBarView;
@@ -69,7 +69,7 @@ public class NoteActivity extends ActionBarActivity {
         }
 
         context = getApplicationContext();
-        content = (EditText) findViewById(R.id.note_content);
+        content = (HighlightingEditor)findViewById(R.id.note_content);
         noteTitle = (EditText) findViewById(R.id.edit_note_title);
         scrollView = (ScrollView) findViewById(R.id.note_scrollview);
         keyboardBarView = (ViewGroup) findViewById(R.id.keyboard_bar);

--- a/app/src/main/java/me/writeily/pro/editor/Highlighter.java
+++ b/app/src/main/java/me/writeily/pro/editor/Highlighter.java
@@ -1,0 +1,135 @@
+package me.writeily.pro.editor;
+
+import android.graphics.Typeface;
+import android.text.Editable;
+import android.text.ParcelableSpan;
+import android.text.Spannable;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.CharacterStyle;
+import android.text.style.ForegroundColorSpan;
+import android.text.style.StrikethroughSpan;
+import android.text.style.StyleSpan;
+import android.text.style.TypefaceSpan;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class Highlighter {
+
+    final HighlighterColors colors;
+
+    public Highlighter(final HighlighterColors colors) {
+        this.colors = colors;
+    }
+
+    enum HighlighterPattern {
+        LIST(Pattern.compile("\\n\\s+(\\*|\\d*\\.)\\s")),
+        HEADER(Pattern.compile("(((\\n|^)#+.*?\\n)|((\\n|^).*?\\n(-|=)+))")),
+        LINK(Pattern.compile("\\[[^\\]]*\\]\\([^\\)]*\\)")),
+        STRIKETHROUGH(Pattern.compile("~~.+~~")),
+        MONOSPACED(Pattern.compile("`.+`")),
+        BOLD(Pattern.compile("\\*{2}.+?\\*{2}")),
+        ITALICS(Pattern.compile("[^\\*]\\*[^\\*\\n]+\\*[^\\*]"));
+
+        private Pattern pattern;
+
+        HighlighterPattern(Pattern pattern) {
+            this.pattern = pattern;
+        }
+    }
+
+    public Editable run(Editable e) {
+        try {
+            clearSpans(e);
+
+            if (e.length() == 0)
+                return e;
+
+            createColorSpanForMatches(e, HighlighterPattern.HEADER.pattern, colors.getHeaderColor());
+            createColorSpanForMatches(e, HighlighterPattern.LINK.pattern, colors.getLinkColor());
+            createColorSpanForMatches(e, HighlighterPattern.LIST.pattern, colors.getListColor());
+            createStyleSpanForMatches(e, HighlighterPattern.BOLD.pattern, Typeface.BOLD);
+            createStyleSpanForMatches(e, HighlighterPattern.ITALICS.pattern, Typeface.ITALIC);
+            createSpanWithStrikeThroughForMatches(e, HighlighterPattern.STRIKETHROUGH.pattern);
+            createMonospaceSpanForMatches(e, HighlighterPattern.MONOSPACED.pattern);
+
+        } catch (Exception ex) {
+            // Ignoring errors
+        }
+
+        return e;
+    }
+
+    private void createMonospaceSpanForMatches(Editable e, Pattern pattern) {
+        createSpanForMatches(e, pattern, new SpanCreator() {
+            @Override
+            public ParcelableSpan create() {
+                return new TypefaceSpan("monospace");
+            }
+        });
+
+    }
+
+    private void createSpanWithStrikeThroughForMatches(Editable e, Pattern pattern) {
+
+        createSpanForMatches(e, pattern, new SpanCreator() {
+            @Override
+            public ParcelableSpan create() {
+                return new StrikethroughSpan();
+            }
+        });
+    }
+
+    private void createStyleSpanForMatches(final Editable e, final Pattern pattern,
+                                           final int style) {
+        createSpanForMatches(e, pattern, new SpanCreator() {
+            @Override
+            public ParcelableSpan create() {
+                return new StyleSpan(style);
+            }
+        });
+    }
+
+    private void createColorSpanForMatches(final Editable e, final Pattern pattern,
+                                           final int color) {
+        createSpanForMatches(e, pattern, new SpanCreator() {
+            @Override
+            public ParcelableSpan create() {
+                return new ForegroundColorSpan(color);
+            }
+        });
+    }
+
+
+    private void createSpanForMatches(final Editable e, final Pattern pattern,
+                                      final SpanCreator spanCreator) {
+        for (Matcher m = pattern.matcher(e);
+             m.find(); ) {
+            e.setSpan(
+                    spanCreator.create(),
+                    m.start(),
+                    m.end(),
+                    Spannable.SPAN_EXCLUSIVE_EXCLUSIVE);
+        }
+
+    }
+
+    private void clearSpans(Editable e) {
+
+        clearSpanType(e, ForegroundColorSpan.class);
+        clearSpanType(e, BackgroundColorSpan.class);
+        clearSpanType(e, StrikethroughSpan.class);
+        clearSpanType(e, StyleSpan.class);
+    }
+
+    private <T extends CharacterStyle> void clearSpanType(Editable e, Class<T> spanType) {
+
+        CharacterStyle[] spans = e.getSpans(0, e.length(), spanType);
+
+        for (int n = spans.length; n-- > 0; ) {
+            e.removeSpan(spans[n]);
+        }
+    }
+}

--- a/app/src/main/java/me/writeily/pro/editor/HighlighterColors.java
+++ b/app/src/main/java/me/writeily/pro/editor/HighlighterColors.java
@@ -1,0 +1,7 @@
+package me.writeily.pro.editor;
+
+public interface HighlighterColors {
+    int getHeaderColor();
+    int getLinkColor();
+    int getListColor();
+}

--- a/app/src/main/java/me/writeily/pro/editor/HighlightingEditor.java
+++ b/app/src/main/java/me/writeily/pro/editor/HighlightingEditor.java
@@ -1,0 +1,193 @@
+package me.writeily.pro.editor;
+
+import android.content.Context;
+import android.os.Handler;
+import android.text.Editable;
+import android.text.InputFilter;
+import android.text.Spanned;
+import android.text.TextWatcher;
+import android.util.AttributeSet;
+import android.widget.EditText;
+
+public class HighlightingEditor extends EditText {
+
+    private Highlighter highlighter;
+
+    interface OnTextChangedListener {
+        void onTextChanged(String text);
+    }
+
+    public OnTextChangedListener onTextChangedListener = null;
+    public int updateDelay = 100;
+    public boolean dirty = false;
+
+    private final Handler updateHandler = new Handler();
+    private final Runnable updateRunnable =
+            new Runnable() {
+                @Override
+                public void run() {
+                    Editable e = getText();
+
+                    if (onTextChangedListener != null)
+                        onTextChangedListener.onTextChanged(e.toString());
+
+                    highlightWithoutChange(e);
+                }
+            };
+    private boolean modified = true;
+
+    public HighlightingEditor(Context context) {
+        super(context);
+        init();
+    }
+
+    public HighlightingEditor(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        init();
+    }
+
+    private void init() {
+
+        setHorizontallyScrolling(true);
+
+        setFilters(new InputFilter[]{new IndentationFilter()});
+
+        addTextChangedListener(
+                new TextWatcher() {
+                    @Override
+                    public void onTextChanged(
+                            CharSequence s,
+                            int start,
+                            int before,
+                            int count) {
+                    }
+
+                    @Override
+                    public void beforeTextChanged(
+                            CharSequence s,
+                            int start,
+                            int count,
+                            int after) {
+                    }
+
+                    @Override
+                    public void afterTextChanged(Editable e) {
+                        cancelUpdate();
+
+                        if (!modified)
+                            return;
+
+                        dirty = true;
+                        updateHandler.postDelayed(
+                                updateRunnable,
+                                updateDelay);
+                    }
+                });
+
+        highlighter = new Highlighter(new HighlighterColors() {
+
+            private static final int COLOR_HEADER = 0xffef6C00;
+            private static final int COLOR_LINK = 0xff1ea3fd;
+            private static final int COLOR_LIST = COLOR_HEADER;
+
+            @Override
+            public int getHeaderColor() {
+                return COLOR_HEADER;
+            }
+
+            @Override
+            public int getLinkColor() {
+                return COLOR_LINK;
+            }
+
+            @Override
+            public int getListColor() {
+                return COLOR_LIST;
+            }
+        });
+    }
+
+    private void cancelUpdate() {
+        updateHandler.removeCallbacks(updateRunnable);
+    }
+
+    private void highlightWithoutChange(Editable e) {
+        modified = false;
+        highlighter.run(e);
+        modified = true;
+    }
+
+    private class IndentationFilter implements InputFilter {
+        @Override
+        public CharSequence filter(
+                CharSequence source,
+                int start,
+                int end,
+                Spanned dest,
+                int dstart,
+                int dend) {
+
+            if (modified &&
+                    end - start == 1 &&
+                    start < source.length() &&
+                    dstart < dest.length()) {
+                char c = source.charAt(start);
+
+                if (c == '\n')
+                    return autoIndent(
+                            source,
+                            dest,
+                            dstart,
+                            dend);
+            }
+
+            return source;
+        }
+
+        private CharSequence autoIndent(CharSequence source, Spanned dest, int dstart, int dend) {
+
+            int istart = findLineBreakPosition(dest, dstart);
+
+            // append white space of previous line and new indent
+            return source + createIndentForNextLine(dest, dend, istart);
+        }
+
+        private int findLineBreakPosition(Spanned dest, int dstart) {
+            int istart = dstart - 1;
+
+            for (; istart > -1; --istart) {
+                char c = dest.charAt(istart);
+
+                if (c == '\n')
+                    break;
+            }
+            return istart;
+        }
+
+        private String createIndentForNextLine(Spanned dest, int dend, int istart) {
+            if (istart > -1) {
+                int iend;
+
+                for (iend = ++istart;
+                     iend < dend;
+                     ++iend) {
+                    char c = dest.charAt(iend);
+
+                    if (c != ' ' &&
+                            c != '\t') {
+                        break;
+                    }
+                }
+
+                return dest.subSequence(istart, iend) + addBulletPointIfNeeded(dest.charAt(iend));
+            } else {
+                return "";
+            }
+        }
+
+        private String addBulletPointIfNeeded(char character) {
+            return character == '*' ? Character.toString(character) + " " : "";
+        }
+    }
+
+}

--- a/app/src/main/java/me/writeily/pro/editor/SpanCreator.java
+++ b/app/src/main/java/me/writeily/pro/editor/SpanCreator.java
@@ -1,0 +1,7 @@
+package me.writeily.pro.editor;
+
+import android.text.ParcelableSpan;
+
+public interface SpanCreator {
+    ParcelableSpan create();
+}

--- a/app/src/main/res/layout/activity_note.xml
+++ b/app/src/main/res/layout/activity_note.xml
@@ -15,7 +15,7 @@
         android:layout_weight="1"
         android:fillViewport="true">
 
-        <EditText
+        <me.writeily.pro.editor.HighlightingEditor
             android:id="@+id/note_content"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -10,6 +10,8 @@
     <string name="pref_pin_key">pref_pin</string>
     <string name="pref_preview_first_key">pref_edit_first_key</string>
     <string name="pref_show_markdown_shortcuts_key">pref_show_markdown_shortcuts_key</string>
+    <string name="pref_highlighting_activated_key">pref_highlighting_activated_key</string>
+    <string name="pref_highlighting_delay_key">pref_highlighting_delay_key</string>
     <string name="pref_remember_directory_key">pref_remember_directory_key</string>
     <string name="pref_last_open_directory">pref_last_open_directory</string>
     <string name="pref_font_choice_key">pref_font_choice</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -63,6 +63,9 @@
     <string name="pref_font_size">Font Size</string>
     <string name="pref_pin">Pin Lock</string>
     <string name="pref_show_markdown_shortcuts">Show Markdown shortcuts bar</string>
+    <string name="pref_highlighting_activated">Markdown syntax highlighting</string>
+    <string name="pref_highlighting_delay">Delay in miliseconds for highlighting refresh</string>
+    <string name="pref_highlighting_delay_summary">Higher values are easier on the battery</string>
     <string name="pin_title">Enter your pin</string>
     <string name="pin_go">Go</string>
 

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -49,6 +49,20 @@
             android:key="@string/pref_show_markdown_shortcuts_key"
             android:title="@string/pref_show_markdown_shortcuts" />
 
+        <CheckBoxPreference
+            android:defaultValue="true"
+            android:key="@string/pref_highlighting_activated_key"
+            android:title="@string/pref_highlighting_activated" />
+
+        <EditTextPreference
+            android:defaultValue="500"
+            android:inputType="number"
+            android:numeric="integer"
+            android:key="@string/pref_highlighting_delay_key"
+            android:title="@string/pref_highlighting_delay"
+            android:summary="@string/pref_highlighting_delay_summary"
+            android:dependency="@string/pref_highlighting_activated_key"/>
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/social">


### PR DESCRIPTION
I added a very naive implementation of syntax highlighting (headers, lists, links, bold, italic, monospace and strikethrough are supported at this stage).
It can be activated/deactivated through preferences. The syntax refresh delay is also configurable, for battery-life paranoids.