### PR TITLE
Back button fixes

### DIFF
--- a/app/src/main/java/me/writeily/pro/MainActivity.java
+++ b/app/src/main/java/me/writeily/pro/MainActivity.java
@@ -8,6 +8,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.res.Configuration;
 import android.os.Bundle;
+import android.os.Handler;
 import android.preference.PreferenceManager;
 import android.support.v4.view.GravityCompat;
 import android.support.v4.view.MenuItemCompat;
@@ -97,6 +98,7 @@ public class MainActivity extends ActionBarActivity {
     };
 
     private RenameBroadcastReceiver renameBroadcastReceiver = new RenameBroadcastReceiver();
+    private boolean doubleBackToExitPressedOnce;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -407,5 +409,34 @@ public class MainActivity extends ActionBarActivity {
             // Close the drawer
             drawerLayout.closeDrawer(drawerView);
         }
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (doubleBackToExitPressedOnce) {
+            super.onBackPressed();
+            return;
+        }
+
+        if (drawerLayout.isDrawerOpen(drawerView)) {
+            drawerLayout.closeDrawer(drawerView);
+        } else if (!onRootDirectory()) {
+            notesFragment.goToPreviousDir();
+        } else {
+            this.doubleBackToExitPressedOnce = true;
+            Toast.makeText(this, "Please click BACK again to exit", Toast.LENGTH_SHORT).show();
+
+            new Handler().postDelayed(new Runnable() {
+
+                @Override
+                public void run() {
+                    doubleBackToExitPressedOnce = false;
+                }
+            }, 2000);
+        }
+    }
+
+    private boolean onRootDirectory() {
+        return findViewById(R.id.previous_dir_button).getVisibility() != View.VISIBLE;
     }
 }

--- a/app/src/main/java/me/writeily/pro/NotesFragment.java
+++ b/app/src/main/java/me/writeily/pro/NotesFragment.java
@@ -80,7 +80,7 @@ public class NotesFragment extends Fragment {
         filesListView.setMultiChoiceModeListener(new ActionModeCallback());
         filesListView.setAdapter(filesAdapter);
 
-        previousDirButton = (Button) layoutView.findViewById(R.id.import_header_btn);
+        previousDirButton = (Button) layoutView.findViewById(R.id.previous_dir_button);
         previousDirButton.setOnClickListener(new PreviousDirClickListener());
 
         rootDir = getRootFolderFromPrefsOrDefault();
@@ -196,7 +196,7 @@ public class NotesFragment extends Fragment {
         checkDirectoryStatus();
     }
 
-    private void goToPreviousDir() {
+    public void goToPreviousDir() {
         if (currentDir != null) {
             currentDir = currentDir.getParentFile();
         }

--- a/app/src/main/res/layout/notes_fragment.xml
+++ b/app/src/main/res/layout/notes_fragment.xml
@@ -15,7 +15,7 @@
         android:textSize="24sp"/>
 
     <Button
-        android:id="@+id/import_header_btn"
+        android:id="@+id/previous_dir_button"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/toolbar"
@@ -34,7 +34,7 @@
         android:id="@+id/notes_listview"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_below="@id/import_header_btn"
+        android:layout_below="@id/previous_dir_button"
         android:choiceMode="multipleChoiceModal"
         android:layout_gravity="start"
         android:background="@android:color/transparent" />


### PR DESCRIPTION
Back button moves up one level in the directory hierarchy. Once at root level, pressing back twice triggers the regular "back" behaviour. If drawer is open, pressing back button closes it. Fixes jffrymrtn/writeily-pro#84