### PR TITLE
add right-to-left (rtl) rendering support

### DIFF
--- a/app/src/main/java/me/writeily/model/Constants.java
+++ b/app/src/main/java/me/writeily/model/Constants.java
@@ -55,8 +55,10 @@ public class Constants {
 
     // ----- HTML PREFIX AND SUFFIXES -----
     public static final String UNSTYLED_HTML_PREFIX = "<html><body>";
-    public static final String MD_HTML_PREFIX = "<html><head><style type=\"text/css\">html,body{padding:4px 8px 4px 8px;font-family:'sans-serif-light';color:#303030;}h1,h2,h3,h4,h5,h6{font-family:'sans-serif-condensed';}a{color:#388E3C;text-decoration:underline;}img{height:auto;width:325px;margin:auto;}</style></head><body>";
-    public static final String DARK_MD_HTML_PREFIX = "<html><head><style type=\"text/css\">html,body{padding:4px 8px 4px 8px;font-family:'sans-serif-light';color:#ffffff;background-color:#303030;}h1,h2,h3,h4,h5,h6{font-family:'sans-serif-condensed';}a{color:#388E3C;text-decoration:underline;}a:visited{color:#dddddd;}img{height:auto;width:325px;margin:auto;}</style></head><body>";
+    public static final String MD_HTML_PREFIX = "<html><head><style type=\"text/css\">html,body{padding:4px 8px 4px 8px;font-family:'sans-serif-light';color:#303030;}h1,h2,h3,h4,h5,h6{font-family:'sans-serif-condensed';}a{color:#388E3C;text-decoration:underline;}img{height:auto;width:325px;margin:auto;}</style>";
+    public static final String DARK_MD_HTML_PREFIX = "<html><head><style type=\"text/css\">html,body{padding:4px 8px 4px 8px;font-family:'sans-serif-light';color:#ffffff;background-color:#303030;}h1,h2,h3,h4,h5,h6{font-family:'sans-serif-condensed';}a{color:#388E3C;text-decoration:underline;}a:visited{color:#dddddd;}img{height:auto;width:325px;margin:auto;}</style>";
+    public static final String MD_HTML_PREFIX_END = "</head><body>";
+    public static final String MD_HTML_RTL_CSS = "<style>body{text-align:right; direction:rtl;}</style>";
     public static final String MD_HTML_SUFFIX = "</body></html>";
     public static final String TARGET_DIR = "note_source_dir";
 

--- a/app/src/main/java/me/writeily/renderer/MarkDownRenderer.java
+++ b/app/src/main/java/me/writeily/renderer/MarkDownRenderer.java
@@ -19,14 +19,18 @@ public class MarkDownRenderer {
 
     private String themeStringFromContext(Context context) {
         String theme = getThemeFromPrefs(context);
+	    String s = "";
         if (!theme.equals("")) {
             if (theme.equals(context.getString(R.string.theme_dark))) {
-                return Constants.DARK_MD_HTML_PREFIX;
+                s += Constants.DARK_MD_HTML_PREFIX;
             } else {
-                return Constants.MD_HTML_PREFIX;
+                s += Constants.MD_HTML_PREFIX;
             }
+	        if (PreferenceManager.getDefaultSharedPreferences(context).getBoolean(context.getString(R.string.pref_render_rtl_key), false))
+		        s += Constants.MD_HTML_RTL_CSS;
+	        s += Constants.MD_HTML_PREFIX_END;
         }
-        return "";
+        return s;
     }
 
     private String getThemeFromPrefs(Context context) {

--- a/app/src/main/res/values/donottranslate.xml
+++ b/app/src/main/res/values/donottranslate.xml
@@ -22,6 +22,7 @@
     <string name="pref_email_key">pref_email_key</string>
     <string name="pref_about_key">pref_about</string>
     <string name="pref_smart_shortcuts_key">pref_smart_shortcuts_key</string>
+    <string name="pref_render_rtl_key">pref_render_rtl_key</string>
 
     <string name="twitter_url">https://twitter.com/writeily</string>
     <string name="writeily_url">https://play.google.com/store/apps/details?id=me.writeily</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
     <string name="pref_highlighting_delay_summary">Higher values are easier on the battery</string>
     <string name="pref_smart_shortcuts">Smart brackets shortcuts</string>
     <string name="pref_smart_shortcuts_summary">If text is selected, {}, [] and () will surround the selection</string>
+    <string name="pref_render_rtl">Render for right-to-left languages</string>
     <string name="pin_title">Enter your pin</string>
     <string name="passphrase_title">Enter your passphrase</string>
     <string name="pin_go">Go</string>

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -78,6 +78,11 @@
             android:title="@string/pref_smart_shortcuts"
             android:summary="@string/pref_smart_shortcuts_summary" />
 
+	    <CheckBoxPreference
+		    android:defaultValue="false"
+		    android:key="@string/pref_render_rtl_key"
+		    android:title="@string/pref_render_rtl" />
+
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/social">


### PR DESCRIPTION
Hello

In some languages such as Persian and Hebrew, text flows from right to left. Currently, the support for such languages  by markdown editors is dismal. I have added this RTL rendering option due to my need and I think it would be useful for some others too. It adds a checkbox to the preferences screen which causes required CSS to be added to the rendered HTML.

Regards,
Fadishei
