### PR TITLE
enable dropbox 'open with...' intents to work

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,6 +30,8 @@
 
                 <data android:mimeType="text/plain"
                     android:scheme="file"/>
+                <data android:mimeType="application/octet-stream"
+                    android:scheme="file"/>
             </intent-filter>
 
             <intent-filter>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -24,6 +24,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.SEND" />
                 <action android:name="android.intent.action.EDIT" />
+                <action android:name="android.intent.action.VIEW" />
 
                 <category android:name="android.intent.category.DEFAULT" />
 

--- a/app/src/main/java/me/writeily/NoteActivity.java
+++ b/app/src/main/java/me/writeily/NoteActivity.java
@@ -88,6 +88,8 @@ public class NoteActivity extends ActionBarActivity {
             openFromSendAction(receivingIntent);
         } else if (Intent.ACTION_EDIT.equals(intentAction) && type != null) {
             openFromEditAction(receivingIntent);
+        } else if (Intent.ACTION_VIEW.equals(intentAction) && type != null) {
+            openFromViewAction(receivingIntent);
         } else {
             note = (File) getIntent().getSerializableExtra(Constants.NOTE_KEY);
         }
@@ -111,6 +113,12 @@ public class NoteActivity extends ActionBarActivity {
     private void openFromEditAction(Intent receivingIntent) {
         Uri fileUri = receivingIntent.getData();
         readFileUriFromIntent(fileUri);
+    }
+
+    private void openFromViewAction(Intent receivingIntent) {
+        Uri fileUri = receivingIntent.getData();
+        note = new File(fileUri.getPath());
+        content.setText(WriteilySingleton.getInstance().readFileUri(fileUri, this));
     }
 
     private void readFileUriFromIntent(Uri fileUri) {


### PR DESCRIPTION
These changes allow opening, editing and saving changes with Writeily from the Dropbox app. Single test on my phone.
