### PR TITLE
Sort File Listings into Alphabetical Order

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -20,12 +20,12 @@ android {
 
 repositories {
     maven {
-        url "https://repo.commonsware.com.s3.amazonaws.com"
+        url "https://s3.amazonaws.com/repo.commonsware.com"
     }
 }
 
 dependencies {
-    compile 'com.commonsware.cwac:anddown:0.2.4'
+    compile 'com.commonsware.cwac:anddown:0.3.0'
     compile 'com.android.support:appcompat-v7:22.1.1'
     compile 'com.android.support:recyclerview-v7:21.0.3'
     compile 'com.getbase:floatingactionbutton:1.3.0'

--- a/app/src/main/java/me/writeily/model/WriteilySingleton.java
+++ b/app/src/main/java/me/writeily/model/WriteilySingleton.java
@@ -19,6 +19,9 @@ import java.io.UnsupportedEncodingException;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 /**
@@ -195,7 +198,15 @@ public class WriteilySingleton {
     public ArrayList<File> addFilesFromDirectory(File sourceDir, ArrayList<File> files) {
         ArrayList<File> addedFiles = new ArrayList<>();
 
-        for (File f : sourceDir.listFiles()) {
+        List<File> listedData = Arrays.asList(sourceDir.listFiles());
+        Collections.sort(listedData, new Comparator<File>() {
+            @Override
+            public int compare(File f1, File f2) {
+                return f1.getName().compareToIgnoreCase(f2.getName());
+            }
+        });
+
+        for (File f : listedData) {
             if (!f.getName().startsWith(".")) {
                 if (f.isDirectory()) {
                     files.add(f);

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.1.2'
+        classpath 'com.android.tools.build:gradle:2.2.3'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.2.3'
+        classpath 'com.android.tools.build:gradle:2.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Fri Jul 29 00:44:23 PDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Jul 29 00:44:23 PDT 2016
+#Sun Feb 05 09:26:46 PST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.10-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip


### PR DESCRIPTION
Currently file listings seem to occur in the OS order, which may be very unpredictable, this is very inconvenient for large directories. This sorts the files in Alphabetical order making it much easier to find things.

This also updates gradle to the latest version.
